### PR TITLE
Build and Deploy .NET Package on Tag Push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build package
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build HibernateGenerator/HibernateGenerator.csproj -c:Release
+      # - run: |
+      #     ls -la HibernateGenerator/bin/Release/net8.0/HibernateGenerator.dll
+      - name: Upload dotnet test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: result
+          path: HibernateGenerator/bin/Release/net8.0/HibernateGenerator.dll
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: HibernateGenerator/bin/Release/net8.0/HibernateGenerator.dll


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow that automatically builds and deploys the .NET package upon pushing a tag that follows the version pattern v*.*.*. The workflow includes the following steps:

Checkout the repository, including submodules.
Set up the .NET 8.0 environment.
Restore project dependencies using dotnet restore.
Build the project in Release mode targeting the .NET 8.0 framework.
Upload the generated DLL as an artifact for the build.
Publish the build artifact as a GitHub release using the versioned tag.
This automation ensures that every versioned release is properly built and deployed.